### PR TITLE
Allow using this plugin in monorepos

### DIFF
--- a/messages/package.json
+++ b/messages/package.json
@@ -1,6 +1,7 @@
 {
   "commandDescription": "Generates a Metadata Package using the differences between two git refs (branch or commit)",
   "outputdirDescription": "The directory to output the generated package and metadata to",
+  "workingdirDescription": "The path to the directory containing the salesforce project",
   "toBranchDescription": "The git ref (branch or commit) which we are deploying into. Defaults to master",
   "fromBranchDescription": "The git ref (branch or commit) which we are deploying from. If left blank, will use head",
   "force": "Continue even if source is behind target",


### PR DESCRIPTION
The current way of selecting files matches `git diff` results [against the source paths configured in the sfdx config file](https://github.com/callawaycloud/sfdx-git-packager/blob/272452d48d244948a766e79973b7a847efe6c3d8/src/commands/git/package.ts#L229). Unfortunately, this prevents having the source code into a sub directory, like in a monorepo context. In my case, the code is in a `apps/salesforce` directory and no change is detected. The plugin crashed with the following message:

> `WARNING: No changes found!`

This PR is a very raw proposal to shine a light on this issue and start the discussion about how it should be solved.

The way I do it is a bit hacky and uses a new flag as an example. I have not tested it yet.

I think a better way would be to use the following command to detect the relative path of files to the git root.

```
git rev-parse --show-prefix
```

This requires a lot more work but I think it would make the plugin more versatile.
